### PR TITLE
Fix index using the return code instead of socket id

### DIFF
--- a/source/lwip/iot_socket.c
+++ b/source/lwip/iot_socket.c
@@ -182,7 +182,7 @@ int32_t iotSocketBind (int32_t socket, const uint8_t *ip, uint32_t ip_len, uint1
     }
     return rc;
   }
-  sock_attr[rc-LWIP_SOCKET_OFFSET].bound = 1;
+  sock_attr[socket-LWIP_SOCKET_OFFSET].bound = 1;
   return rc;
 }
 


### PR DESCRIPTION
The lwip implementation of sockets has a bug where the status of bind is incorrectly stored because the wrong index is used. This fixes the index which should use the socket id, since the return of bind is 0 on success, not the socket id.