### PR TITLE
Add option to allow reuse of local address by sockets

### DIFF
--- a/documentation/src/IoT_Socket_API.txt
+++ b/documentation/src/IoT_Socket_API.txt
@@ -60,6 +60,9 @@
 \details Enables or disables the keep-alive mode for the stream socket.
 \def IOT_SOCKET_SO_TYPE
 \details Obtains the type of the socket.
+\def IOT_SOCKET_SO_REUSEADDR
+\details Set socket to allow reuse of local address.
+
 @}
 */
 
@@ -585,6 +588,7 @@ Option                       | Description
 \ref IOT_SOCKET_SO_RCVTIMEO  | Timeout for receiving in blocking mode
 \ref IOT_SOCKET_SO_SNDTIMEO  | Timeout for sending in blocking mode
 \ref IOT_SOCKET_SO_KEEPALIVE | Keep-alive mode for the stream socket
+\ref IOT_SOCKET_SO_REUSEADDR | Set socket to allow reuse of local address
 
 The argument \em opt_val points to the buffer containing the value of the \em opt_id.
 

--- a/include/iot_socket.h
+++ b/include/iot_socket.h
@@ -65,6 +65,7 @@ extern "C"
 #define IOT_SOCKET_SO_SNDTIMEO          3       ///< Send timeout in ms (default = 0); opt_val = &timeout, opt_len = sizeof(timeout)
 #define IOT_SOCKET_SO_KEEPALIVE         4       ///< Keep-alive messages (default = 0); opt_val = &keepalive, opt_len = sizeof(keepalive), keepalive (integer): 0=disabled, enabled otherwise
 #define IOT_SOCKET_SO_TYPE              5       ///< Socket Type (Get only); opt_val = &socket_type, opt_len = sizeof(socket_type), socket_type (integer): IOT_SOCKET_SOCK_xxx
+#define IOT_SOCKET_SO_REUSEADDR         6       ///< Reuse of local address (Set only, default = 0); opt_val = &reuseaddr, opt_len = sizeof(reuseaddr), reuseaddr (integer): enabled if non-zero
 
 /**** Socket Return Codes ****/
 #define IOT_SOCKET_ERROR                (-1)    ///< Unspecified error

--- a/source/lwip/iot_socket.c
+++ b/source/lwip/iot_socket.c
@@ -625,6 +625,9 @@ int32_t iotSocketSetOpt (int32_t socket, int32_t opt_id, const void *opt_val, ui
       break;
     case IOT_SOCKET_SO_TYPE:
       return IOT_SOCKET_EINVAL;
+    case IOT_SOCKET_SO_REUSEADDR:
+      rc = setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, (const char *)opt_val, opt_len);
+      break;
     default:
       return IOT_SOCKET_EINVAL;
   }

--- a/source/mdk_network/iot_socket.c
+++ b/source/mdk_network/iot_socket.c
@@ -609,6 +609,8 @@ int32_t iotSocketSetOpt (int32_t socket, int32_t opt_id, const void *opt_val, ui
       break;
     case IOT_SOCKET_SO_TYPE:
       return IOT_SOCKET_EINVAL;
+    case IOT_SOCKET_SO_REUSEADDR:
+      return IOT_SOCKET_ENOTSUP;
     default:
       return IOT_SOCKET_EINVAL;
   }


### PR DESCRIPTION
Added IOT_SOCKET_SO_REUSEADDR as a set only option. We need this for our secure sockets implementation. Set option will return IOT_SOCKET_ENOTSUP if not support by implementation.